### PR TITLE
Update raw swift file URLs

### DIFF
--- a/Sources/FlatBuffersSwiftCodeGen/main.swift
+++ b/Sources/FlatBuffersSwiftCodeGen/main.swift
@@ -53,11 +53,11 @@ if let swiftFileContent = schema?.swift(withImport: !withoutImport) {
 if CommandLine.arguments.count > 3
     && CommandLine.arguments[3] == "download" {
     print("🕐 Downloading FlatBuffersBuilder")
-    let builderData = try Data(contentsOf: URL(string: "https://github.com/mzaks/FlatBuffersSwift/blob/1.0.0/FlatBuffersSwift/FlatBuffersBuilder.swift")!)
+    let builderData = try Data(contentsOf: URL(string: "https://raw.github.com/mzaks/FlatBuffersSwift/1.0.0/FlatBuffersSwift/FlatBuffersBuilder.swift")!)
     try!builderData.write(to: swiftUrl.deletingLastPathComponent().appendingPathComponent("FlatBuffersBuilder.swift"))
     print("✅ Completed")
     print("🕐 Downloading FlatBuffersReader")
-    let readerData = try Data(contentsOf: URL(string: "https://github.com/mzaks/FlatBuffersSwift/blob/1.0.0/FlatBuffersSwift/FlatBuffersReader.swift")!)
+    let readerData = try Data(contentsOf: URL(string: "https://raw.githubusercontent.com/mzaks/FlatBuffersSwift/1.0.0/FlatBuffersSwift/FlatBuffersReader.swift")!)
     try!readerData.write(to: swiftUrl.deletingLastPathComponent().appendingPathComponent("FlatBuffersReader.swift"))
     print("✅ Completed")
 }


### PR DESCRIPTION
Raw URLs of `FlatBuffersBuilder.swift` and `FlatBuffersReader.swift` have changed from `blob` to `raw.github.com`.