### PR TITLE
fix: Use raw.githubusercontent instead of raw.github

### DIFF
--- a/Sources/FlatBuffersSwiftCodeGen/main.swift
+++ b/Sources/FlatBuffersSwiftCodeGen/main.swift
@@ -53,7 +53,7 @@ if let swiftFileContent = schema?.swift(withImport: !withoutImport) {
 if CommandLine.arguments.count > 3
     && CommandLine.arguments[3] == "download" {
     print("🕐 Downloading FlatBuffersBuilder")
-    let builderData = try Data(contentsOf: URL(string: "https://raw.github.com/mzaks/FlatBuffersSwift/1.0.0/FlatBuffersSwift/FlatBuffersBuilder.swift")!)
+    let builderData = try Data(contentsOf: URL(string: "https://raw.githubusercontent.com/mzaks/FlatBuffersSwift/1.0.0/FlatBuffersSwift/FlatBuffersBuilder.swift")!)
     try!builderData.write(to: swiftUrl.deletingLastPathComponent().appendingPathComponent("FlatBuffersBuilder.swift"))
     print("✅ Completed")
     print("🕐 Downloading FlatBuffersReader")


### PR DESCRIPTION
This should fix #5.

It seems that the redirect of raw.github to raw.githubusercontent does not work reliably. Therefore it would be neat to not rely on that. 

If you have anything to add, please let me know